### PR TITLE
example: Fix error when running android

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -31,6 +31,9 @@ allprojects {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")
         }
+        flatDir {
+            dirs "$rootDir/../node_modules/react-native-tappay/android/libs"
+        }
 
         google()
         maven { url 'https://www.jitpack.io' }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -26,3 +26,7 @@ android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.99.0
+
+# Fix "Entry name 'AndroidManifest.xml' collided" issue
+# https://stackoverflow.com/a/60441372/9636125
+android.useNewApkCreator=false


### PR DESCRIPTION
When run `$ yarn android` will receive an error:
```
Execution failed for task ':app:mergeDebugAssets'.
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Could not find :tpdirect:.
     Required by:
         project :app > project :react-native-tappay
```
Add `dirs "$rootDir/../node_modules/react-native-tappay/android/libs"` to `android/build.gradle` to fix it.

When run it again, will receive `Entry name 'AndroidManifest.xml' collided` error, use [this](https://stackoverflow.com/a/60441372/9636125) solution to fix it.