### PR TITLE
chore: Adjust tsconfig

### DIFF
--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["src"]
+}

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -5,6 +5,7 @@ module.exports = {
     "eslint",
     () => 'tsc -p tsconfig.json',
   ],
+  "example/src/*.{ts,tsx}": [() => 'tsc -p example/tsconfig.json'],
   "*.json": [
     "prettier --write"
   ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,5 +28,5 @@
   },
   "types": ["react", "react-native", "jest"],
   "exclude": ["android/**/*", "ios/**/*", "dist/**/*"],
-  "include": ["src", "example"]
+  "include": ["src"]
 }


### PR DESCRIPTION
避免 `example` 被編譯進 `dist`，特別分開 `example` 的 `tsconfig.json`。