### PR TITLE
feat: add support ApplePay for Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,18 @@ Returns: `Promise<boolean>`
 Parameters: [MerchantData](https://github.com/VeryBuy/react-native-tappay/edit/master/README.md#merchantdata), CartData[[CartItem](https://github.com/VeryBuy/react-native-tappay/edit/master/README.md#cartitem)] <br>
 Returns: `Promise<{ prime: string | null }>`
 
-### isApplePayAvailable(IOS Only)
+### isApplePayAvailable(IOS/Web Only)
 Parameters: `void`<br>
 Returns: `Promise<boolean>`
+
+### webSetupApplePay(Web Only)
+Parameters: [MerchantData](https://github.com/VeryBuy/react-native-tappay/edit/master/README.md#merchantdata), CartData[[CartItem](https://github.com/VeryBuy/react-native-tappay/edit/master/README.md#cartitem)] <br>
+Returns: `Promise<boolean>`
+
+### webGetApplePayPrime(Web Only)
+Parameters: `void`<br>
+Returns: `Promise<{ prime: string | null }>`
+
 
 #### Types
 
@@ -284,6 +293,7 @@ merchantReferenceInfo | `{ affiliate_codes: Array }`  |
  - [x] [Direct Pay](https://www.tappaysdk.com/en/payments/direct-pay)
  - [x] [Line Pay](https://www.tappaysdk.com/en/payments/line-pay)
  - [x] [Apple Pay](https://www.tappaysdk.com/en/payments/apple-pay)
+ - [x] [Apple Pay for Web](https://www.tappaysdk.com/en/payments/apple-pay)
  - [ ] [Google Pay](https://www.tappaysdk.com/en/payments/google-pay) PR Welcome
  - [ ] [Samsung Pay](https://www.tappaysdk.com/en/payments/samsung-pay) PR Welcome
 

--- a/android/src/main/java/tw/com/verybuy/tappay/TapPayModule.java
+++ b/android/src/main/java/tw/com/verybuy/tappay/TapPayModule.java
@@ -226,12 +226,12 @@ public class TapPayModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void isApplePayAvailable(final Promise promise) throws TPDLinePayException {
+    public void isApplePayAvailable(final Promise promise) {
         promise.resolve(false);
     }
 
     @ReactMethod
-    public void getApplePayPrime(final Promise promise) throws TPDLinePayException {
+    public void getApplePayPrime(final Promise promise) {
         promise.reject("Fail", "Not Support on Android");
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-tappay",
   "title": "React Native TapPay",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "TODO",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/src/types/TapPayInstance.ts
+++ b/src/types/TapPayInstance.ts
@@ -1,9 +1,10 @@
+import type { CartData, MerchantData } from './applePay';
 import {
   CardSetupArgs,
   GetCardPrimeResolveValue,
   UpdateCallback,
 } from './card';
-
+export type { MerchantData, CartData } from './applePay';
 export interface SetupArgs {
   appId: number;
   appKey: string;
@@ -11,17 +12,6 @@ export interface SetupArgs {
   rbaId?: string;
   rbaKey?: string;
 }
-export interface MerchantData {
-  merchantName: string;
-  merchantIdentifier: string;
-  countryCode: string;
-  currencyCode: string;
-}
-export interface CartItem {
-  itemName: string;
-  price: number;
-}
-export type CartData = Array<CartItem>;
 
 type IsLoadedSuccess = boolean;
 

--- a/src/types/TapPayInstance.ts
+++ b/src/types/TapPayInstance.ts
@@ -42,4 +42,9 @@ export default interface TapPayInstance {
     merchantData: MerchantData,
     cartData: CartData,
   ) => Promise<{ prime: string | null }>;
+  webSetupApplePay: (
+    merchantData: MerchantData,
+    cartData: CartData,
+  ) => Promise<boolean>;
+  webGetApplePayPrime: () => Promise<{ prime: string | null }>;
 }

--- a/src/types/TapPayInstance.ts
+++ b/src/types/TapPayInstance.ts
@@ -45,6 +45,6 @@ export default interface TapPayInstance {
   webSetupApplePay: (
     merchantData: MerchantData,
     cartData: CartData,
-  ) => Promise<boolean>;
+  ) => Promise<any>;
   webGetApplePayPrime: () => Promise<{ prime: string | null }>;
 }

--- a/src/types/applePay.ts
+++ b/src/types/applePay.ts
@@ -1,0 +1,12 @@
+export interface MerchantData {
+  merchantName: string;
+  merchantIdentifier: string;
+  countryCode: string;
+  currencyCode: string;
+}
+export interface CartItem {
+  itemName: string;
+  price: number;
+}
+
+export type CartData = Array<CartItem>;

--- a/src/types/web/index.ts
+++ b/src/types/web/index.ts
@@ -6,6 +6,7 @@ export interface TapPayDirect {
     setupApplePay: Function;
     setupPaymentRequest: Function;
     getPrime: Function;
+    checkAvailability: Function;
   };
   appID: string;
   setupSDK: Function;

--- a/src/types/web/index.ts
+++ b/src/types/web/index.ts
@@ -2,6 +2,11 @@ import { CardSetupArgs, GetCardPrime, UpdateCallback } from './card';
 import { GetLinePayPrime } from './linePay';
 
 export interface TapPayDirect {
+  paymentRequestApi: {
+    setupApplePay: Function;
+    setupPaymentRequest: Function;
+    getPrime: Function;
+  };
   appID: string;
   setupSDK: Function;
   linePay: {

--- a/src/web/TapPay.ts
+++ b/src/web/TapPay.ts
@@ -145,10 +145,14 @@ export class TapPayMethods {
       },
     };
 
-    window.TPDirect.paymentRequestApi.setupPaymentRequest(data, result => {
-      console.log('======setupPaymentRequest START======');
-      console.log(result);
-      console.log('======setupPaymentRequest END======');
+    return new Promise((resolve, reject) => {
+      window.TPDirect.paymentRequestApi.setupPaymentRequest(data, result => {
+        if (result.canMakePaymentError) {
+          reject(result);
+        } else {
+          resolve(result);
+        }
+      });
     });
   };
 

--- a/src/web/TapPay.ts
+++ b/src/web/TapPay.ts
@@ -114,11 +114,7 @@ export class TapPayMethods {
     return Promise.resolve(true);
   };
 
-  isApplePayAvailable = () => {
-    return Promise.resolve(false);
-  };
-
-  setupApplePay = (merchantData: MerchantData) => {
+  isApplePayAvailable = (merchantData: MerchantData, cartData: CartData) => {
     window.TPDirect.paymentRequestApi.setupApplePay({
       merchantIdentifier: merchantData.merchantIdentifier,
       countryCode: merchantData.countryCode,
@@ -130,7 +126,7 @@ export class TapPayMethods {
         label: merchantData.merchantName,
         amount: {
           currency: merchantData.currencyCode,
-          value: '1.00',
+          value: cartData.reduce((prev, current) => current.price + prev, 0),
         },
       },
     };
@@ -138,21 +134,16 @@ export class TapPayMethods {
     return new Promise((resolve, reject) => {
       window.TPDirect.paymentRequestApi.setupPaymentRequest(data, result => {
         if (!result.browserSupportPaymentRequest) {
-          if (!result.canMakePaymentWithActiveCard) {
-            reject(result);
-          }
-        }
-        // eslint-disable-next-line
-        if (window.ApplePaySession) {
-          resolve(result);
-        } else {
           reject(result);
+
+          return;
         }
+        resolve(true);
       });
     });
   };
 
-  getApplePayPrime = (_merchantData?: MerchantData, _cartData?: CartData) => {
+  getApplePayPrime = () => {
     return new Promise((resolve, reject) => {
       window.TPDirect.paymentRequestApi.getPrime(result => {
         if (result.prime) {

--- a/src/web/TapPay.ts
+++ b/src/web/TapPay.ts
@@ -114,7 +114,21 @@ export class TapPayMethods {
     return Promise.resolve(true);
   };
 
-  isApplePayAvailable = (merchantData: MerchantData, cartData: CartData) => {
+  isApplePayAvailable = () => {
+    return Promise.resolve(
+      window.TPDirect.paymentRequestApi.checkAvailability(),
+    );
+  };
+
+  getApplePayPrime = () => {
+    console.warn(
+      'You have to call webSetupApplePay and webGetApplePayPrime instead.',
+    );
+
+    return Promise.reject('Not Support on Web');
+  };
+
+  webSetupApplePay = (merchantData: MerchantData, cartData: CartData) => {
     window.TPDirect.paymentRequestApi.setupApplePay({
       merchantIdentifier: merchantData.merchantIdentifier,
       countryCode: merchantData.countryCode,
@@ -131,19 +145,14 @@ export class TapPayMethods {
       },
     };
 
-    return new Promise((resolve, reject) => {
-      window.TPDirect.paymentRequestApi.setupPaymentRequest(data, result => {
-        if (!result.browserSupportPaymentRequest) {
-          reject(result);
-
-          return;
-        }
-        resolve(true);
-      });
+    window.TPDirect.paymentRequestApi.setupPaymentRequest(data, result => {
+      console.log('======setupPaymentRequest START======');
+      console.log(result);
+      console.log('======setupPaymentRequest END======');
     });
   };
 
-  getApplePayPrime = () => {
+  webGetApplePayPrime = () => {
     return new Promise((resolve, reject) => {
       window.TPDirect.paymentRequestApi.getPrime(result => {
         if (result.prime) {

--- a/src/web/TapPay.ts
+++ b/src/web/TapPay.ts
@@ -145,7 +145,7 @@ export class TapPayMethods {
       },
     };
 
-    return new Promise((resolve, reject) => {
+    return new Promise<any>((resolve, reject) => {
       window.TPDirect.paymentRequestApi.setupPaymentRequest(data, result => {
         if (result.canMakePaymentError) {
           reject(result);
@@ -157,14 +157,16 @@ export class TapPayMethods {
   };
 
   webGetApplePayPrime = () => {
-    return new Promise((resolve, reject) => {
-      window.TPDirect.paymentRequestApi.getPrime(result => {
-        if (result.prime) {
-          resolve(result);
-        } else {
-          reject(result);
-        }
-      });
+    return new Promise<any>((resolve, reject) => {
+      window.TPDirect.paymentRequestApi.getPrime(
+        (result: { prime: string }) => {
+          if (result?.prime) {
+            resolve(result);
+          } else {
+            reject(result);
+          }
+        },
+      );
     });
   };
 }

--- a/src/web/constant.ts
+++ b/src/web/constant.ts
@@ -1,2 +1,2 @@
 export const TPDIframeId = 'TPDirectIframe';
-export const TAP_PAY_SDK_PATH = 'https://js.tappaysdk.com/tpdirect/v5.6.0';
+export const TAP_PAY_SDK_PATH = 'https://js.tappaysdk.com/tpdirect/v5.12.3';

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -38,7 +38,5 @@ export function useTapPay(args: SetupArgs): UseTapPay {
     }
   }, [isLoadedSuccess, appId, rbaId, rbaKey, appKey, env]);
 
-  // eslint-disable-next-line
-  // @ts-ignore
   return [isLoadedSuccess, tapPayInstance];
 }

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -38,5 +38,7 @@ export function useTapPay(args: SetupArgs): UseTapPay {
     }
   }, [isLoadedSuccess, appId, rbaId, rbaKey, appKey, env]);
 
+  // eslint-disable-next-line
+  // @ts-ignore
   return [isLoadedSuccess, tapPayInstance];
 }


### PR DESCRIPTION

由於 payment API 需要使用者互動才能進行取得 prime 的動作，最後考慮將 web 拆出來
* webSetupApplePay
* webGetApplePayPrime

```ts
// DidMount or CartData is ready
TapPay.webSetupApplePay(merchantData, cartData);

// OnPress
TapPay.webGetApplePayPrime();